### PR TITLE
clean up the local directory forcibly

### DIFF
--- a/gitolize.sh
+++ b/gitolize.sh
@@ -233,7 +233,7 @@ fi
 
 if [[ "$CLEANUP_LOCAL_DIRECTORY" ]]
 then
-  rm -r "$LOCAL_DIRECTORY"
+  rm -rf "$LOCAL_DIRECTORY"
 fi
 
 exit "$EXIT_CODE"


### PR DESCRIPTION
This is to avoid the following on macOS:

```console
% ./pulumi.sh version
v3.101.1
override r--r--r-- Filip.Zyzniewski/staff for /var/folders/xc/rb73zyjd3kq26tv0hpk4wxh40000gq/T/tmp.D1f4iRjD8G/.git/objects/pack/pack-0f1841e9611258ae579b331d7e5ef8e24c3e674e.idx? y
override r--r--r-- Filip.Zyzniewski/staff for /var/folders/xc/rb73zyjd3kq26tv0hpk4wxh40000gq/T/tmp.D1f4iRjD8G/.git/objects/pack/pack-0f1841e9611258ae579b331d7e5ef8e24c3e674e.pack? y
%
```